### PR TITLE
Fixed #176: Corrected a typo to reset the unread mention count for a channel when leaving it.

### DIFF
--- a/app/client/subscribe.js
+++ b/app/client/subscribe.js
@@ -40,7 +40,7 @@ function subscribeToLatestChatroomLog () {
             messageContainsNick(fields.message, userServer.current_nick) &&
             (
               !(
-                currentRouter.params.serverName = userServer.name &&
+                currentRouter.params.serverName == userServer.name &&
                 '#' + currentRouter.params.channelName == channel.name
               ) || !window_focus
             )


### PR DESCRIPTION
A correction in typo to reset unread mentions count for a channel when leaving it.
