### PR TITLE
Removed autofocus property on chat input for small screens

### DIFF
--- a/app/.meteor/packages
+++ b/app/.meteor/packages
@@ -53,4 +53,5 @@ mrt:chosen-package@0.11.1
 npm-container
 meteorhacks:npm
 force-ssl
+device-detection
 

--- a/app/client/chat/_lib/helpers.js
+++ b/app/client/chat/_lib/helpers.js
@@ -30,7 +30,9 @@ waartaa.chat.helpers.highlightServerRoom = function () {
       waartaa.chat.helpers.roomAccessedTimestamp.reset('server', room);
       waartaa.chat.helpers.unreadLogsCount.clear('server', room);
   }
-  $('#chat-input').focus();
+  if (Meteor.Device.isDesktop() || Meteor.Device.isTV()){
+    $('#chat-input').focus();
+  }
   //refreshAutocompleteNicksSource();
   Meteor.setTimeout(function () {
     $('.chat-logs-container')


### PR DESCRIPTION
Removed the property of autofocus using device-detection module, and set it only for TV and Destop.
